### PR TITLE
Fix thumbnail positioning

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,4 +72,10 @@ Check the `examples/index.html` file for a working example.
 
 This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details.
 
+
+## How to contribute
+
+- Suggest changes into Issues
+- Open Pull Requests on dev branch with improved code/new features and explain it
+
 ---

--- a/src/videojs-vtt-thumbnails.css
+++ b/src/videojs-vtt-thumbnails.css
@@ -1,7 +1,6 @@
 .thumbnail-preview {
   position: absolute;
-  bottom: 170px;
-  margin-left: -50px;
+  bottom: 70px;
   pointer-events: none;
   display: none;
   z-index: 0;
@@ -14,6 +13,7 @@
   background-repeat: no-repeat;
   pointer-events: none; 
   display: none;
+  transform: translateX(-50%) translateY(-100%);
 }
 
 .video-js .thumbnail-preview .thumbnail {

--- a/src/videojs-vtt-thumbnails.css
+++ b/src/videojs-vtt-thumbnails.css
@@ -1,6 +1,6 @@
 .thumbnail-preview {
   position: absolute;
-  bottom: 50px;
+  bottom: 55px;
   pointer-events: none;
   display: none;
   z-index: 0;

--- a/src/videojs-vtt-thumbnails.css
+++ b/src/videojs-vtt-thumbnails.css
@@ -1,6 +1,6 @@
 .thumbnail-preview {
   position: absolute;
-  bottom: 70px;
+  bottom: 50px;
   pointer-events: none;
   display: none;
   z-index: 0;

--- a/src/videojs-vtt-thumbnails.js
+++ b/src/videojs-vtt-thumbnails.js
@@ -59,7 +59,7 @@
             thumbnail.className = 'thumbnail';
             thumbnail.dataset.startTime = startTime;
 
-            const percentage = startTime / player.duration();
+            const percentage = startTime / (player.duration() || 1);
             const progressBar = player.controlBar.progressControl.el();
             const barRect = progressBar.getBoundingClientRect();
             thumbnail.style.left = `${barRect.width * percentage}px`;
@@ -108,7 +108,9 @@
                 closestThumbnail.style.display = 'block';
             }
 
-            thumbnailContainer.style.left = e.pageX + 'px';
+            const playerRect = player.el().getBoundingClientRect();
+
+            thumbnailContainer.style.left = (e.pageX - playerRect.left) + 'px';
             thumbnailContainer.style.display = 'block';
         });
 

--- a/src/videojs-vtt-thumbnails.js
+++ b/src/videojs-vtt-thumbnails.js
@@ -59,11 +59,6 @@
             thumbnail.className = 'thumbnail';
             thumbnail.dataset.startTime = startTime;
 
-            const percentage = startTime / (player.duration() || 1);
-            const progressBar = player.controlBar.progressControl.el();
-            const barRect = progressBar.getBoundingClientRect();
-            thumbnail.style.left = `${barRect.width * percentage}px`;
-
             thumbnail.style.backgroundImage = `url(${spriteUrl})`;
             thumbnail.style.backgroundPosition = `-${x}px -${y}px`;
             thumbnail.style.width = `${width}px`;


### PR DESCRIPTION
First of all, thanks for this plugin. It's almost perfect for my use case, and without it as a starting point I probably wouldn't have ended up with a nice final solution.

This PR fixes three issues:

1. The thumbnail position is only correct if your player takes up the entire viewport. If there is padding around the player then the position of the thumbnail is offset by that padding and no longer lines up with the cursor. To solve this, instead of setting the thumbnail container's .left position to `mouseEvent.pageX`, it is set to `mouseEvent.pageX - playerBoundingRect.left`.
2. The center of the thumbnail only aligns with the cursor if using thumbnails that are 100px wide as in the example (due to the fixed -50px margin on the thumbnail container). To solve this, I remove the fixed -50px margin on the container and apply a -50% translation to the individual thumbnail. I also remove the .left positioning on the individual thumbnails.
3. The thumbnail's vertical position is only correct if using the same thumbnail height as in the example (due to the 170px bottom positioning on the thumbnail container). This was setting the position of the top of the thumbnail to 170px above the bottom of the player, which works fine with short thumbnails but then the thumbnail will start overflowing out of the bottom of the player if it is larger. To solve this, I applied a fixed 50px bottom positioning to the thumbnail container and a -100% vertical translation to the individual thumbnails. Now rather than the top of the thumbnail being set to 170px above the bottom of the player, the bottom of the thumbnail is set to 50px above the bottom of the player, allowing the thumbnail to grow upwards if needed.

Let me know if any issues.
Cheers.